### PR TITLE
matplotlib/artist.py doesn't like alpha=nan

### DIFF
--- a/src/rydiqule/energy_diagram.py
+++ b/src/rydiqule/energy_diagram.py
@@ -94,6 +94,11 @@ def draw_wiggly_arrow(ax: plt.Axes, start: Collection, stop: Collection,
         Matplotlib alpha specification.
         Default is 1.
     """
+    if np.isnan(alpha):
+        alpha = 1
+    alpha = min(1.0, alpha)
+    alpha = max(0.0, alpha)
+
     start = np.array(start)
     stop = np.array(stop)
     vec = stop-start


### PR DESCRIPTION
I fixed this in energy_diagram.py, but it would probably be more robust to not assign nan to alpha higher up in the code.
```
Traceback (most recent call last):
  File "<string>", line 17, in __PYTHON_EL_eval
  File "<string>", line 3, in <module>
  File "/var/folders/j8/mxqqlzds1f1gv45c2zr8_vp452lpyy/T/babel-1FFnas/python-6AEL5q", line 10, in <module>
    rq.draw_diagram(sensor)
  File "<path-to>/rydiqule/src/rydiqule/sensor_utils.py", line 571, in draw_diagram
    fig, ax = diagram.plot(show_IDs=True)
  File "<path-to>/rydiqule/src/rydiqule/energy_diagram.py", line 445, in plot
    draw_wiggly_arrow(self.ax, (x1,y1),
  File "<path-to>/rydiqule/src/rydiqule/energy_diagram.py", line 108, in draw_wiggly_arrow
    line = mpl.lines.Line2D(x0,y0,color=color,alpha=alpha,linestyle=linestyle)
  File "<path-to-lib>/Python/3.9/lib/python/site-packages/matplotlib/_api/deprecation.py", line 454, in wrapper
    return func(*args, **kwargs)
  File "<path-to-lib>/Python/3.9/lib/python/site-packages/matplotlib/lines.py", line 393, in __init__
    self._internal_update(kwargs)
  File "<path-to-lib>/Python/3.9/lib/python/site-packages/matplotlib/artist.py", line 1186, in _internal_update
    return self._update_props(
  File "<path-to-lib>/Python/3.9/lib/python/site-packages/matplotlib/artist.py", line 1162, in _update_props
    ret.append(func(v))
  File "<path-to-lib>/Python/3.9/lib/python/site-packages/matplotlib/artist.py", line 983, in set_alpha
    raise ValueError(f'alpha ({alpha}) is outside 0-1 range')
ValueError: alpha (nan) is outside 0-1 range
```