### PR TITLE
set Rabi frequency of forbidden transitions to zero

### DIFF
--- a/src/rydiqule/cell.py
+++ b/src/rydiqule/cell.py
@@ -524,7 +524,11 @@ class Cell(Sensor):
                     passed_rabi = float(passed_rabi)
 
         elif (e_field is None and beam_power is None and rabi_frequency is not None):
-            passed_rabi = rabi_frequency
+            if np.abs(dipole_moment) > np.finfo(float).eps:
+                passed_rabi = rabi_frequency
+            else:
+                passed_rabi = 0
+                warnings.warn(f'This coupling is a forbidden transition: {state1} -> {state2}; q={q}')
 
         else:
             msg = ("Please only define one of: 1) rabi_frequency or "


### PR DESCRIPTION
In Cell, coupling strengths specified by Rabi frequency were simulated even when the transition was dipole forbidden.

This change forcesthe Rabi frequency to zero is the dipole moment (which was already being calculated) is less than the floating point epsilon of the system. Also, a warning is issued to the user.