### PR TITLE
Add Cs133 to atom_utils.ATOM list...

### DIFF
--- a/src/rydiqule/atom_utils.py
+++ b/src/rydiqule/atom_utils.py
@@ -15,7 +15,7 @@ ATOMS = {
     'Na': arc_atoms.Sodium,
     'K39': arc_atoms.Potassium39, 'K40': arc_atoms.Potassium40, 'K41': arc_atoms.Potassium41,
     'Rb85': arc_atoms.Rubidium85, 'Rb87': arc_atoms.Rubidium87,
-    'Cs': arc_atoms.Caesium
+    'Cs': arc_atoms.Caesium, 'Cs133': arc_atoms.Caesium
 }
 """
 Alkali atoms defined by ARC that can be used with :class:`~.Cell`.

--- a/src/rydiqule/cell.py
+++ b/src/rydiqule/cell.py
@@ -18,7 +18,7 @@ from typing import Literal, Optional, Sequence, List, Tuple, Callable, Union
 
 a0 = scipy.constants.physical_constants["Bohr radius"][0]
 
-AtomFlags = Literal['H', 'Li6', 'Li7', 'Na', 'K39', 'K40', 'K41', 'Rb85', 'Rb87', 'Cs']
+AtomFlags = Literal['H', 'Li6', 'Li7', 'Na', 'K39', 'K40', 'K41', 'Rb85', 'Rb87', 'Cs', 'Cs133']
 QState = Sequence  # TODO: consider using named tuples here
 States = Tuple[int, ...]
 
@@ -48,7 +48,7 @@ class Cell(Sensor):
         ----------
         atom_flag : str 
             Which atom is used in the cell for calculating physical properties with ARC Rydberg.
-            One of ['H', 'Li6', 'Li7', 'Na', 'K39', 'K40', 'K41', 'Rb85', 'Rb87', 'Cs'].
+            One of ['H', 'Li6', 'Li7', 'Na', 'K39', 'K40', 'K41', 'Rb85', 'Rb87', 'Cs', 'Cs133'].
         atomic_states : list[list]
             List of states to be added to the cell. Each state is 
             an iterable whose elements are each a list of the form [n, l, j, m], represnting the 


### PR DESCRIPTION
v1.1.0 strips isotope numbers out of the atom name, so not all changes that I had previously proposed are necesary.

cell.py has only documentation changes.