### PR TITLE
v1.1.0 to v1.2.0 commits

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,95 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it using the preferred article citation.
+title: RydIQule
+abstract: >-
+  The Rydberg Interactive Quantum module is a modeling library designed to simulate the response of Rydberg atoms to arbitrary input RF waveforms.
+  It functions as a general master equation solver for quantum systems based on the semi-classical density matrix method.
+authors:
+  - family-names: Miller
+    given-names: Benjamin N
+    orcid: 'https://orcid.org/0000-0003-0017-1355'
+  - family-names: Meyer
+    given-names: David H
+    orcid: 'https://orcid.org/0000-0003-2452-2017'
+  - family-names: Virtanen
+    given-names: Teemu
+  - family-names: O'Brien
+    given-names: Christopher M
+    orcid: 'https://orcid.org/0000-0003-2974-0531'
+  - family-names: Cox
+    given-names: Kevin C
+    orcid: 'https://orcid.org/0000-0001-5049-3999'
+
+version: 1.1.0
+date-released: "2023-10-11"
+license: Apache-2.0
+repository-code: "https://github.com/QTC-UMD/rydiqule"
+url: "https://doi.org/10.1016/j.cpc.2023.108952"
+
+identifiers:
+  - description: Journal article describing the software
+    doi: 10.1016/j.cpc.2023.108952
+
+preferred-citation:
+  type: article
+  title: "RydIQule: A Graph-based paradigm for modeling Rydberg and atomic sensors"
+  authors:
+    - family-names: Miller
+      given-names: Benjamin N
+    - family-names: Meyer
+      given-names: David H
+      orcid: 'https://orcid.org/0000-0003-2452-2017'
+    - family-names: Virtanen
+      given-names: Teemu
+    - family-names: O'Brien
+      given-names: Christopher M
+    - family-names: Cox
+      given-names: Kevin C
+  doi: "10.1016/j.cpc.2023.108952"
+  journal: "Computer Physics Communications"
+  month: 1
+  year: 2024
+  start: 108952 # page number
+  issue: 294
+
+references:
+  - type: software
+    title: ARC (Alkali.ne Rydberg Calculator)
+    authors:
+      - family-names: Šibalić
+        given-names: Nikola
+    repository-code: "https://github.com/nikolasibalic"
+    url: "http://arc-alkali-rydberg-calculator.readthedocs.io/"
+  - type: software
+    title: NetworkX
+    repository-code: "https://github.com/networkx/networkx"
+    url: "https://networkx.org"
+  - type: software
+    title: NumPy
+    repository-code: "https://github.com/numpy/numpy"
+    url: "https://numpy.org"
+  - type: software
+    title: SciPy
+    repository-code: "https://github.com/scipy/scipy"
+    url: "https://scipy.org"
+  - type: software
+    title: numbakit-ode
+    authors:
+      - family-names: Grecco
+        given-names: Hernan E
+    repository-code: "https://github.com/hgrecco/numbakit-ode"
+    url: "https://numbakit-ode.readthedocs.io/en/latest/index.html"
+  - type: software
+    title: CyRK
+    authors:
+      - family-names: Renaud
+        given-names: Joe P
+    repository-code: "https://github.com/jrenaud90/CyRK"
+  - type: software
+    title: leveldiagram
+    authors:
+      - family-names: Meyer
+        given-names: David H
+    repository-code: "https://github.com/dihm/leveldiagram"
+    url: "https://leveldiagram.readthedocs.io/en/latest"
+    

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 <img src="https://raw.githubusercontent.com/QTC-UMD/rydiqule/main/docs/source/img/Rydiqule_Logo_Transparent_300.png" alt="rydiqule" style="max-width: 100%;">
 
-The Rydberg Interactive Quantum module is a modelling library designed to simulate
-the response of a Rydberg atoms to arbitrary input RF waveforms.
+The Rydberg Interactive Quantum module is a modeling library designed to simulate
+the response of Rydberg atoms to arbitrary input RF waveforms.
 It also functions as a general master equation solver based on the semi-classical density matrix method.
 
 [![PyPI](https://img.shields.io/pypi/v/rydiqule.svg)](https://pypi.org/project/rydiqule)
 [![Python Version](https://img.shields.io/pypi/pyversions/rydiqule.svg)](https://python.org)
 [![License](https://img.shields.io/pypi/l/rydiqule.svg)](https://github.com/QTC-UMD/rydiqule/raw/main/LICENSE)
 [![Docs](https://readthedocs.org/projects/rydiqule/badge/?version=latest)](https://rydiqule.readthedocs.io/en/latest)
+
+### Please cite as
+
+B. N Miller, D. H. Meyer, T. Virtanen, C. M O'Brien, and K. C. Cox,
+RydIQule: A Graph-based paradigm for modeling Rydberg and atomic sensors,
+*Computer Physics Communications*, **294**, 108952 (2024)
+[https://doi.org/10.1016/j.cpc.2023.108952](https://doi.org/10.1016/j.cpc.2023.108952)
 
 ## Installation
 
@@ -43,8 +50,8 @@ Now use pip to install rydiqule and remaining dependencies.
 ```shell
 # for normal installation
 (rydiqule) ~/> pip install rydiqule
-# for editable installation, so source can be modified locally
-(rydiqule) ~/> pip install -e rydiqule
+# for editable installation of cloned repo, so source can be modified locally
+(rydiqule) ~/> pip install -e .
 ```
 
 ### Pure pip installation
@@ -55,9 +62,10 @@ pip install rydiqule
 ```
 This command will use pip to install all necessary dependencies.
 
-To install in an editable way (which allows edits of the source code), run:
+To install in an editable way (which allows edits of the source code),
+run the following from the root directory of the cloned repository:
 ```shell
-pip install -e rydiqule
+pip install -e .
 ```
 
 ### Confirm installation
@@ -70,8 +78,8 @@ Proper installation can be confirmed by executing the following commands in a py
         Rydiqule
     ================
 
-Rydiqule Version:     1.0.0
-Installation Path:    C:\Users\naqsL\Miniconda3\envs\rydiqule\lib\site-packages\rydiqule
+Rydiqule Version:     1.1.0
+Installation Path:    ~\Miniconda3\envs\rydiqule\lib\site-packages\rydiqule
 
       Dependencies
     ================
@@ -81,7 +89,7 @@ SciPy Version:        1.10.1
 Matplotlib Version:   3.7.1
 ARC Version:          3.3.0
 Python Version:       3.9.16
-Python Install Path:  C:\Users\naqsL\Miniconda3\envs\rydiqule
+Python Install Path:  ~\Miniconda3\envs\rydiqule
 Platform Info:        Windows (AMD64)
 CPU Count:            12
 Total System Memory:  128 GB
@@ -90,16 +98,17 @@ Total System Memory:  128 GB
 ### Updating an existing installation
 
 Upgrading an existing installation is simple.
-Simply run the pip installation commands described above with the update flag.
+Simply run the pip installation commands described above.
+Optionally, include the update flag to greedily update dependencies as well.
 ```shell
 pip install -U rydiqule
 ```
 This command will also install any new dependencies that are required.
 
 If using an editable install, simply replacing the files in the same directory is sufficient.
-Though it is recommended to also run the appropriate pip update command as well.
+Though it is recommended to also run the appropriate pip update command as well to capture updated dependencies.
 ```shell
-pip install -U -e rydiqule
+pip install -U -e .
 ```
 
 ### Dependencies

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+v1.2.0
+------
+
+Improvements
+++++++++++++
+
+- Level diagrams now use `Sensor.get_rotating_frames` to provide better plotting of energy ordering of levels.
+- Level diagrams now allow for optional control of plotting parameters by manually specifying `ld_kw` options on nodes and edges.
+- Added the ability to specify energy level shifts (additional Hamiltonian digonal terms) not accounted for by the coupling infrastructure.
+
+
+Bug Fixes
++++++++++
+
+- `Sensor.make_real` now returns correct sized `const` array when ground is not removed.
+- Many updates to type hints to improve their accuracy.
+
+Deprecations
+++++++++++++
+
+- Remove `Solution._variable_parameters` in favor of property checking the observable parameters.
+- Renamed `Sensor.basis()` and `Solution.basis` to `Sensor.dm_basis()` and `Solution.dm_basis`
+  to disambiguate physical basis from computational basis.
+
 v1.1.0
 ------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,31 @@ For more details, see the :doc:`overview`.
 
 For detailed usage examples, see the :doc:`_intro_nbs/Introduction_To_Rydiqule/Introduction_To_Rydiqule` Jupyter notebook.
 
+If you use rydiqule in your work, please cite as
+
+.. raw:: html
+
+   <details>
+     <summary>B. N. Miller, <em>et. al.</em>, <u><a href="https://doi.org/10.1016/j.cpc.2023.108952">RydIQule: A Graph-based paradigm for modeling Rydberg and atomic sensors</a>,</u> <em>Computer Physics Communications</em> <b>294</b>, 108952 (2024). arXiv:<a href="http://arxiv.org/abs/2307.15673">2307.15673</a>.</summary>
+
+.. code-block:: bibtex
+
+   @article{rydiqule_2024,
+      author = {Miller, B. N. and Meyer, D. H. and Virtanen, T. and O'Brien, C. M. and Cox, K. C.},
+      title = {RydIQule: A Graph-based paradigm for modeling Rydberg and atomic sensors},
+      journal = {Computer Physics Communications},
+      volume = {294},
+      pages = {108952},
+      year = {2024},
+      doi = {10.1016/j.cpc.2023.108952},
+      url = {https://doi.org/10.1016/j.cpc.2023.108952},
+      eprint = {https://doi.org/10.1016/j.cpc.2023.108952}
+   }
+
+.. raw:: html
+
+   </details>
+
 .. toctree::
    :maxdepth: 2
    :hidden:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -40,8 +40,8 @@ Now use pip to install rydiqule and remaining dependencies.
 
   # for normal installation
   (rydiqule) ~/Rydiqule> pip install rydiqule
-  # for editable installation, so source can be modified locally
-  (rydiqule) ~/Rydiqule> pip install -e rydiqule
+  # for editable installation of cloned repo, so source can be modified locally
+  (rydiqule) ~/Rydiqule> pip install -e .
 
 Pure pip installation
 ---------------------
@@ -54,11 +54,12 @@ To install normally, run:
 
 This command will use pip to install all necessary dependencies.
 
-To install in an editable way (which allows edits of the source code), run:
+To install in an editable way (which allows edits of the source code), 
+run the following from the root directory of the cloned repository:
 
 .. code-block:: shell
 
-  pip install -e rydiqule
+  pip install -e .
 
 Confirm installation
 --------------------
@@ -73,8 +74,8 @@ Proper installation can be confirmed by executing the following commands in a py
           Rydiqule
       ================
 
-  Rydiqule Version:     1.0.0
-  Installation Path:    C:\Users\naqsL\Miniconda3\envs\rydiqule\lib\site-packages\rydiqule
+  Rydiqule Version:     1.1.0
+  Installation Path:    ~\Miniconda3\envs\rydiqule\lib\site-packages\rydiqule
 
         Dependencies
       ================
@@ -84,7 +85,7 @@ Proper installation can be confirmed by executing the following commands in a py
   Matplotlib Version:   3.7.1
   ARC Version:          3.3.0
   Python Version:       3.9.16
-  Python Install Path:  C:\Users\naqsL\Miniconda3\envs\rydiqule
+  Python Install Path:  ~\Miniconda3\envs\rydiqule
   Platform Info:        Windows (AMD64)
   CPU Count:            12
   Total System Memory:  128 GB
@@ -93,7 +94,8 @@ Updating an existing installation
 ---------------------------------
 
 Upgrading an existing installation is simple.
-Simply run the pip installation commands described above with the update flag.
+Simply run the pip installation commands described above.
+Optionally, include the update flag to greedily update dependencies as well.
 
 .. code-block:: shell
 
@@ -102,11 +104,11 @@ Simply run the pip installation commands described above with the update flag.
 This command will also install any new dependencies that are required.
 
 If using an editable install, simply replacing the files in the same directory is sufficient.
-Though it is recommended to also run the appropriate pip update command as well.
+Though it is recommended to also run the appropriate pip update command as well to capture updated depedencies.
 
 .. code-block:: shell
 
-  pip install -U -e rydiqule
+  pip install -U -e .
 
 
 Dependencies

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,7 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 warn_unreachable = True
 show_error_codes = True
+allow_redefinition = True
 files = src/**/*.py
 plugins = numpy.typing.mypy_plugin
 
@@ -32,7 +33,13 @@ ignore_missing_imports = True
 [mypy-psutil.*]
 ignore_missing_imports = True
 
-# Module options
+[mypy-CyRK.*]
+ignore_missing_imports = True
 
-[mypy-rydiqule.energy_diagram]
-ignore_errors = False
+[mypy-networkx.*]
+ignore_missing_imports = True
+
+[mypy-leveldiagram.*]
+ignore_missing_imports = True
+
+# Module options

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/src/rydiqule/__init__.py
+++ b/src/rydiqule/__init__.py
@@ -15,4 +15,4 @@ from .rydiqule_utils import about
 
 from .slicing.slicing import compute_grid, matrix_slice, memory_size, get_slice_num, get_slice_num_t
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/src/rydiqule/doppler_utils.py
+++ b/src/rydiqule/doppler_utils.py
@@ -34,7 +34,7 @@ class DirectMethod(TypedDict, total=False):
     doppler_velocities: Union[np.ndarray, Sequence]
 
 
-MeshMethod = Union[UniformMethod, SplitMethod, DirectMethod]
+MeshMethod = Union[UniformMethod, IsoPopMethod, SplitMethod, DirectMethod]
 
 
 def get_doppler_equations(base_eoms: np.ndarray,

--- a/src/rydiqule/experiments.py
+++ b/src/rydiqule/experiments.py
@@ -8,7 +8,7 @@ from .solvers import solve_steady_state
 import numpy as np
 import warnings
 
-from typing import Tuple
+from typing import Tuple, List
 
 
 def get_transmission_coef(*args, **kwargs):
@@ -66,7 +66,7 @@ def get_snr(sensor: Sensor,
             phase_quadrature: bool = False,
             diff_nearest: bool = False,
             **kwargs
-            ) -> Tuple[np.ndarray, Tuple[np.ndarray, ...]]:
+            ) -> Tuple[np.ndarray, List[np.ndarray]]:
     """
     Calculate a Sensor's signal-to-noise ratio in standard deviation,
     in a 1Hz bandwidth,
@@ -161,7 +161,6 @@ def get_snr(sensor: Sensor,
                                   'results may not be as expected.'))
 
     full_sols = solve_steady_state(sensor, **kwargs)
-    full_sols._variables_defined('cell_length', 'eta', 'kappa')
     rhos_ij = full_sols.rho_ij(*full_sols.probe_tuple)
 
     _ = full_sols.get_OD()

--- a/src/rydiqule/rydiqule_utils.py
+++ b/src/rydiqule/rydiqule_utils.py
@@ -49,7 +49,9 @@ def about(obscure_paths: bool = True):
 
     """
     home = Path.home()
-    rydiqule_install_path = Path(inspect.getsourcefile(rydiqule)).parent
+    install_path = inspect.getsourcefile(rydiqule)
+    assert install_path is not None
+    rydiqule_install_path = Path(install_path).parent
     try:
         ryd_path = '~' / rydiqule_install_path.relative_to(home)
     except ValueError:

--- a/src/rydiqule/solvers.py
+++ b/src/rydiqule/solvers.py
@@ -150,7 +150,7 @@ def solve_steady_state(
     spatial_dim = sensor.spatial_dim()
 
     # initialize doppler-related quantities
-    doppler_axis_shape: Iterable[int] = ()
+    doppler_axis_shape: Tuple[int, ...] = ()
     dop_classes = None
     doppler_shifts = None
     doppler_axes: Iterable[slice] = ()
@@ -203,17 +203,17 @@ def solve_steady_state(
     # save results to Solution object
     solution.rho = sols
     # specific to observable calculations
-    solution.eta = sensor.eta
-    solution.kappa = sensor.kappa
-    solution.cell_length = sensor.cell_length
-    solution.beam_area = sensor.beam_area
-    solution.probe_freq = sensor.probe_freq
-    solution.probe_tuple = sensor.probe_tuple
+    solution._eta = sensor.eta
+    solution._kappa = sensor.kappa
+    solution._cell_length = sensor.cell_length
+    solution._beam_area = sensor.beam_area
+    solution._probe_freq = sensor.probe_freq
+    solution._probe_tuple = sensor.probe_tuple
     if sensor.probe_tuple is not None:
         probe_rabi = sensor.get_coupling_rabi(sensor.probe_tuple)
-        solution.probe_rabi = probe_rabi
+        solution._probe_rabi = probe_rabi
     else:
-        solution.probe_rabi = None
+        solution._probe_rabi = None
 
     solution.couplings = sensor.get_couplings()
     solution.axis_labels = ([f'doppler_{i:d}' for i in range(spatial_dim) if not sum_doppler]
@@ -221,8 +221,8 @@ def solve_steady_state(
                             + ["density_matrix"])
     solution.axis_values = ([dop_classes for i in range(spatial_dim) if not sum_doppler]
                             + [val for _,_,val in sensor.variable_parameters()]
-                            + [sensor.basis()])
-    solution.basis = sensor.basis()
+                            + [sensor.dm_basis()])
+    solution.dm_basis = sensor.dm_basis()
     solution.rq_version = version("rydiqule")
     solution.doppler_classes = dop_classes
 

--- a/src/rydiqule/stack_solvers/cyrk_solver.py
+++ b/src/rydiqule/stack_solvers/cyrk_solver.py
@@ -10,13 +10,14 @@ except ImportError as e:
     cyrk_available = False
     cyrk_import_error = e
 
-from typing import Sequence, Callable, Union, Tuple
+from typing import Sequence, Callable
+from rydiqule.sensor_utils import TimeFunc
 
 
 def cyrk_solve(eoms_base: np.ndarray, const_base: np.ndarray,
                eom_time_r: np.ndarray, const_r: np.ndarray,
                eom_time_i: np.ndarray, const_i: np.ndarray,
-               time_inputs: Sequence[Callable[[float], Union[float, complex]]],
+               time_inputs: Sequence[TimeFunc],
                t_eval: np.ndarray, init_cond: np.ndarray,
                **kwargs
                ) -> np.ndarray:
@@ -83,7 +84,7 @@ def cyrk_solve(eoms_base: np.ndarray, const_base: np.ndarray,
     OverflowError: If system size exceeds cyrk backend limit of 65535 equations.
         If we see this error a lot, consider getting CyRK project to increase it
         by changing type of `y_size` from unisgned short.
-    """  # noqa
+    """
 
     if not cyrk_available:
         raise ImportError('CyRK backend not installed') from cyrk_import_error
@@ -121,7 +122,7 @@ def cyrk_solve(eoms_base: np.ndarray, const_base: np.ndarray,
 def _derEqns(obes_base: np.ndarray, const_base: np.ndarray,
              obes_time_r: np.ndarray, const_r: np.ndarray,
              obes_time_i: np.ndarray, const_i: np.ndarray,
-             time_inputs: Tuple[Callable[[float], Union[float, complex]]]
+             time_inputs: Sequence[TimeFunc]
              ) -> Callable[[float, np.ndarray, np.ndarray], None]:
     """
     Function to build the callable passed to CyRK's cyrk_ode cython solver.

--- a/src/rydiqule/stack_solvers/nbkode_solver.py
+++ b/src/rydiqule/stack_solvers/nbkode_solver.py
@@ -10,13 +10,14 @@ except ImportError as e:
     nbkode_available = False
     nbkode_import_error = e
 
-from typing import Sequence, Tuple, Callable, Union
+from typing import Sequence, Callable
+from rydiqule.sensor_utils import TimeFunc
 
 
 def nbkode_solve(eoms_base: np.ndarray, const_base: np.ndarray,
                  eom_time_r: np.ndarray, const_r: np.ndarray,
                  eom_time_i: np.ndarray, const_i: np.ndarray,
-                 time_inputs: Sequence[Callable[[float], Union[float, complex]]],
+                 time_inputs: Sequence[TimeFunc],
                  t_eval: np.ndarray, init_cond: np.ndarray, **kwargs
                  ) -> np.ndarray:
     """
@@ -76,7 +77,7 @@ def nbkode_solve(eoms_base: np.ndarray, const_base: np.ndarray,
     numpy.ndarray
         The matrix solution of shape `(*l,n,n_t)`
         representing the density matrix of the system at each time t.
-    """  # noqa
+    """
 
     if not nbkode_available:
         raise ImportError('numbakit-ode backend not installed') from nbkode_import_error
@@ -111,7 +112,7 @@ def nbkode_solve(eoms_base: np.ndarray, const_base: np.ndarray,
 def _derEqns(obes_base: np.ndarray, const_base: np.ndarray,
              obes_time_r: np.ndarray, const_r: np.ndarray,
              obes_time_i: np.ndarray,  const_i: np.ndarray,
-             time_inputs: Tuple[Callable[[float], Union[float, complex]]]
+             time_inputs: Sequence[TimeFunc]
              ) -> Callable[[float, np.ndarray], np.ndarray]:
     """
     Function to build the callable passed to nbkode numba solver.

--- a/src/rydiqule/stack_solvers/nbrk_solver.py
+++ b/src/rydiqule/stack_solvers/nbrk_solver.py
@@ -10,13 +10,14 @@ except ImportError as e:
     nbrk_available = False
     nbrk_import_error = e
 
-from typing import Sequence, Callable, Union, Tuple
+from typing import Sequence, Callable
+from rydiqule.sensor_utils import TimeFunc
 
 
 def nbrk_solve(eoms_base: np.ndarray, const_base: np.ndarray,
                eom_time_r: np.ndarray, const_r: np.ndarray,
                eom_time_i: np.ndarray, const_i: np.ndarray,
-               time_inputs: Sequence[Callable[[float], Union[float, complex]]],
+               time_inputs: Sequence[TimeFunc],
                t_eval: np.ndarray, init_cond: np.ndarray, **kwargs
                ) -> np.ndarray:
     """
@@ -76,7 +77,7 @@ def nbrk_solve(eoms_base: np.ndarray, const_base: np.ndarray,
     numpy.ndarray
         The matrix solution of shape `(*l,n,n_t)`
         representing the density matrix of the system at each time t.
-    """  # noqa
+    """
 
     if not nbrk_available:
         raise ImportError('CyRK backend not installed') from nbrk_import_error
@@ -109,7 +110,7 @@ def nbrk_solve(eoms_base: np.ndarray, const_base: np.ndarray,
 def _derEqns(obes_base: np.ndarray, const_base: np.ndarray,
              obes_time_r: np.ndarray, const_r: np.ndarray,
              obes_time_i: np.ndarray,  const_i: np.ndarray,
-             time_inputs: Tuple[Callable[[float], Union[float, complex]]]
+             time_inputs: Sequence[TimeFunc]
              ) -> Callable[[float, np.ndarray], np.ndarray]:
     """
     Function to build the callable passed to CyRK's nbrk_ode numba solver.

--- a/src/rydiqule/stack_solvers/scipy_solver.py
+++ b/src/rydiqule/stack_solvers/scipy_solver.py
@@ -2,12 +2,13 @@ import numpy as np
 
 from scipy.integrate import solve_ivp
 
-from typing import Sequence, Callable, Union, Literal
+from typing import Sequence, Callable, Literal
+from rydiqule.sensor_utils import TimeFunc
 
 def scipy_solve(eoms_base: np.ndarray, const: np.ndarray,
                 eom_time_r: np.ndarray, const_r: np.ndarray,
                 eom_time_i: np.ndarray, const_i: np.ndarray,
-                time_inputs: Sequence[Callable[[float], Union[float, complex]]],
+                time_inputs: Sequence[TimeFunc],
                 t_eval: np.ndarray, init_cond: np.ndarray,
                 eqns: Literal["loop", "comp"] = "loop",
                 **kwargs
@@ -72,7 +73,7 @@ def scipy_solve(eoms_base: np.ndarray, const: np.ndarray,
     numpy.ndarray
         The matrix solution of shape `(*l,n,n_t)`
         representing the density matrix of the system at each time t.
-    """  # noqa
+    """
     
     _derEqns = {"loop": _derEqns_loop, "comp": _derEqn_comp}
 
@@ -102,7 +103,7 @@ def scipy_solve(eoms_base: np.ndarray, const: np.ndarray,
 def _derEqns_loop(obes_base: np.ndarray, const_base: np.ndarray,
              obes_time_r: np.ndarray, const_r: np.ndarray,
              obes_time_i: np.ndarray,  const_i: np.ndarray,
-             time_inputs: Sequence[Callable[[float], Union[float, complex]]],
+             time_inputs: Sequence[TimeFunc],
              ) -> Callable[[float, np.ndarray], np.ndarray]:
     """
     Function to build the callable passed to scipy's solve_ivp in :func:`~.scipy_solve`.
@@ -138,7 +139,7 @@ def _derEqns_loop(obes_base: np.ndarray, const_base: np.ndarray,
 def _derEqn_comp(obes_base: np.ndarray, const: np.ndarray,
             obes_time_r: np.ndarray, const_r: np.ndarray,
             obes_time_i: np.ndarray,  const_i: np.ndarray,
-            time_inputs: Sequence[Callable[[float], Union[float, complex]]],
+            time_inputs: Sequence[TimeFunc],
             ) -> Callable[[float, np.ndarray], np.ndarray]:
     """
     Function to build the callable passed to scipy's solve_ivp in :func:`~.scipy_solve`.

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -80,7 +80,7 @@ def test_phase_shift_with_steck():
     e_field=1e-7
 
 
-    rb_cell = rq.Sensor(basis_size = 2)
+    rb_cell = rq.Sensor(2)
     rb_cell.set_experiment_values(cell_length=cell_length, probe_freq = probe_freq,
                                   beam_area=beam_area, probe_tuple = (0,1), kappa = kappa)
     rb_cell.set_gamma_matrix(np.array([[0.23229296, 0.00000000e+00],

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -89,13 +89,26 @@ def test_states_validation():
         # too many labels passed
         s._states_valid((0,1,2))
 
-    with pytest.raises(TypeError, match='must be an integer'):
-        # non-integer inputs
-        s._states_valid('01')
-
-    with pytest.raises(ValueError, match='outside the basis size'):
+    with pytest.raises(ValueError, match='not a state in the basis'):
         # outside basis
         s._states_valid((0,2))
+
+
+@pytest.mark.exception
+def test_basis_exception():
+    '''Assures that invalid bases are correctly caught'''
+    #bad state type 
+    with pytest.raises(ValueError, match="must be integers or strings"):
+        s = rq.Sensor(['g', 'e', None])
+    
+    #double state labels
+    with pytest.raises(ValueError, match="All state labels must be unique"):
+        s = rq.Sensor(['g', 'e', 'e'])
+
+    #bad basis type
+    with pytest.raises(TypeError, match="must be an integer or iterable"):
+        l = lambda x: x
+        s = rq.Sensor(l)
 
 
 @pytest.mark.exception

--- a/tests/test_steady_state_ham_gen.py
+++ b/tests/test_steady_state_ham_gen.py
@@ -22,6 +22,20 @@ def test_ladder_5_level():
     np.testing.assert_allclose(ham, expected_ham,
                                err_msg="5 Level ladder failed hamilonian generation")
 
+@pytest.mark.steady_state
+def test_mixed_state_ladder():
+
+    f1 = {'states':('g',1), 'rabi_frequency':0, 'detuning':1}
+    f2 = {'states':(1,2), 'rabi_frequency':0, 'detuning':2}
+    
+    s = Sensor(['g', 1, 2])
+    s.add_couplings(f1, f2)
+
+    expected_ham = np.diag([0, -1, -1-2])
+    ham = s.get_hamiltonian()
+    
+    np.testing.assert_allclose(ham, expected_ham,
+                               err_msg="5 Level ladder failed hamilonian generation")
 
 @pytest.mark.steady_state
 def test_lambda_4_level():
@@ -30,14 +44,24 @@ def test_lambda_4_level():
     f2 = {'states':(1,3), 'rabi_frequency':0, 'detuning':2}
     f3 = {'states':(2,3), 'rabi_frequency':0, 'detuning':4}
 
+    s_f1 = {'states':('a','b'), 'rabi_frequency':0, 'detuning':1}
+    s_f2 = {'states':('b','d'), 'rabi_frequency':0, 'detuning':2}
+    s_f3 = {'states':('c','d'), 'rabi_frequency':0, 'detuning':4}
+
     sensor = Sensor(4)
     sensor.add_couplings(f1, f2, f3)
 
+    sensor_str = Sensor(['a', 'b', 'c', 'd'])
+    sensor_str.add_couplings(s_f1, s_f2, s_f3)
+
     expected_ham = np.diag([0, -1, -1-2+4, -1-2])
     ham = sensor.get_hamiltonian()
+    ham_str = sensor.get_hamiltonian()
 
     np.testing.assert_allclose(ham, expected_ham,
                                err_msg="4 Level lambda failed hamilonian generation")
+    np.testing.assert_allclose(ham_str, expected_ham,
+                               err_msg="4 Level lambda failed ham generation with str labels")
 
 
 @pytest.mark.steady_state
@@ -79,3 +103,17 @@ def test_v_5_cell():
 
     np.testing.assert_allclose(ham, expected_ham,
                                err_msg="5 Level V cell failed hamilonian generation")
+    
+@pytest.mark.steady_state
+def test_e_shift():
+    f1 = {'states':('g',1), 'rabi_frequency':0, 'detuning':1}
+    f2 = {'states':(1,2), 'rabi_frequency':0, 'detuning':2}
+    
+    s = Sensor(['g', 1, 2])
+    s.add_couplings(f1, f2)
+    s.add_energy_shift('g', .5)
+    s.add_energy_shift(1, 1)
+    s.add_energy_shift(2, 1.5)
+
+    expected_ham = np.diag([0, -1, -1-2]) + np.diag([.5, 1, 1.5])
+    ham = s.get_hamiltonian()


### PR DESCRIPTION
This PR updates rydiqule to v1.2.0. 

This release fixes a few small bugs (especially with inaccurate type hints), updates documentation, and adds a number of small features on the path to full hyperfine support. Please read the changelog for details. Note that new features are subject to changes in implementation as well as possibly the interface as we move forward to full hyperfine support.

Important changes:

- **Arbitrary energy level shifts are now supported in `Sensor`!** This allows for the manual definition of DC Stark shifts or DC Larmour shifts to states in `Sensor`. These shifts are also scannable as other parameters.
- **States may now be labeled via strings or integers (current default).** Specification is done at `Sensor` creation where the basis kwarg can now accept a list of ints and strings. The new method `Sensor.states_with_label` allows for regex selection of groups of states by label.
- **Level Diagram plots are slightly more intelligent by default.** This is done by leveraging the output of `Sensor.get_rotating_frames` to draw levels with appropriate higher/lower relative energy. Here is an arbitrary example showing a closed loop and an unconnected set of states.
  
  ![image](https://github.com/QTC-UMD/rydiqule/assets/6655329/5a856933-ebb7-4660-b406-f189bfe6698f)

- **DEPRECATION: `Sensor.basis` and `Solution.basis` have been renamed to `Sensor.dm_basis` and `Solution.dm_basis`.** All references to basis should now unambiguously refer to the atomic basis (ie number of states), and dm_basis refers to the basis of the density matrix elements (2*number of states -1).