### PR TITLE
Update sphinx version pins for RTD builds.

### DIFF
--- a/docs/source/examples/Analytical Doppler Demo.ipynb
+++ b/docs/source/examples/Analytical Doppler Demo.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "This notebook demonstrates how to use rydiqule's implementation ([`solve_doppler_analytic`](https://rydiqule.readthedocs.io/page/api/_autosummary/rydiqule.doppler_exact.solve_doppler_analytic.html#rydiqule-doppler-exact-solve-doppler-analytic)) of the analytical doppler solver described in\n",
     "Omar Nagib and Thad G. Walker, *Exact steady state of perturbed open quantum systems*,\n",
-    "arXiv 2501.06134 (2025) http://arxiv.org/abs/2501.06134\n",
+    "arXiv:[2501.06134](http://arxiv.org/abs/2501.06134) (2025).\n",
     "It contains examples with 1D/2D/3D Doppler averaging along with detailed profiling performance to highlight improvements.\n"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "setuptools_scm>=8"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -54,9 +54,10 @@ backends = [
     "cyrk>=0.12.1",
 ]
 docs = [
-    "Sphinx==7.2.6",
+    "Sphinx==8.2.3",
     "furo==2024.8.6",
-    "myst-nb",
+    "myst-nb==1.2.0",
+    "myst-parser==4.0.1",
     "sphinx-copybutton",
     "sphinxext-opengraph",
     "sphinx-inline-tabs",


### PR DESCRIPTION
Mainly to get sphinx v8, which is a fair bit faster to build.