### PR TITLE
Add time dependence to analytic doppler

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,8 @@ Bug Fixes
   ARC v3.9.0 updated the precision of a constant used in its internal calculations
   that shifts calculated dipole moment values by a small amount.
   It is expected that other plots and values will differ by small amounts when using `Cell` and ARC v3.9.0
+- Fixed bug where `solve_doppler_analytic` ignored parameter time-dependence. 
+  It now follows the behavior of other steady-state solvers by constructing the Hamiltonian and equations of motion at `t=0`.
 
 Deprecations
 ++++++++++++

--- a/src/rydiqule/doppler_exact.py
+++ b/src/rydiqule/doppler_exact.py
@@ -150,6 +150,9 @@ def solve_doppler_analytic(sensor: Sensor, doppler_mesh_method: Optional[MeshMet
     this solver effectively reduces the dimension to 1 or 2, respectively, 
     leading to faster solves.
 
+    If the sensor contains couplings with `time_dependence`, this solver will add those
+    couplings at their :math:`t=0` value to the steady-state hamiltonian to solve. 
+
     If insufficient system memory is available to solve the system in a single call,
     system is broken into "slices" of manageable memory footprint which are solved individually.
     This slicing behavior does not affect the result.
@@ -224,7 +227,7 @@ def solve_doppler_analytic(sensor: Sensor, doppler_mesh_method: Optional[MeshMet
     n = sensor.basis_size
 
     # 1. Get base Liouvillian (L0) and Doppler shifts
-    L0, dummy_const = generate_eom(sensor.get_hamiltonian(), sensor.decoherence_matrix(),
+    L0, dummy_const = generate_eom(sensor.get_time_hamiltonian(t=0), sensor.decoherence_matrix(),
                                    remove_ground_state=False, real_eom=True)
     all_shifts = sensor.get_doppler_shifts()
 


### PR DESCRIPTION
Modify analytic doppler solver to handle time dependence of parameters by solving for steady state at the t=0 values.