### PR TITLE
Cell fixes

### DIFF
--- a/src/rydiqule/atom_utils.py
+++ b/src/rydiqule/atom_utils.py
@@ -4,6 +4,7 @@ Utilities for interacting with atomic parameters and ARC.
 
 from scipy.constants import epsilon_0, hbar, c
 import numpy as np
+import math
 import re
 from .sensor_utils import expand_statespec
 
@@ -667,7 +668,7 @@ def calc_eta(omega: float, dipole_moment:float, beam_area: float) -> float:
         The value of eta, in root(Hz)
     """
 
-    eta = np.sqrt((omega*dipole_moment**2)/(2.0*c*epsilon_0*hbar*beam_area))
+    eta = math.sqrt((omega*dipole_moment**2)/(2.0*c*epsilon_0*hbar*beam_area))
 
     return eta
 
@@ -793,7 +794,7 @@ def validate_qnums(qstate:A_QState, I: Optional[float]=None):
     #validate (n,l) int, j half int
     assert int(n)==n, f"invalid n quantum number {n}."
     assert (int(l)==l) and (l < n), f"invalid l quantum number {l}."
-    assert j==l+1/2 or j==np.abs(l-1/2), f"invalid j quantum number {j}"
+    assert j==l+1/2 or j==abs(l-1/2), f"invalid j quantum number {j}"
 
     #test m_j, f, m_f are allowed values
     if m_j is not None:
@@ -967,7 +968,7 @@ def get_valid_f(state: A_QState, I: Optional[float]=None) -> List[float]:
     J_qnum=state[2]
     if not isinstance(J_qnum, (int, float)) or not isinstance(I, (int, float)):
         raise ValueError(f"Invalid I,J quantum number types {(type(I),type(J_qnum))}.")
-    return np.arange(np.abs(J_qnum - I), J_qnum + I + 1).tolist()
+    return np.arange(abs(J_qnum - I), J_qnum + I + 1).tolist()
 
 
 def get_valid_mf(state: A_QState, I: Optional[float]=None) -> List[float]:

--- a/src/rydiqule/cell.py
+++ b/src/rydiqule/cell.py
@@ -343,7 +343,7 @@ class Cell(Sensor):
 
 
     @property
-    def kappa(self):
+    def kappa(self) -> float:
         """Property to calculate the kappa value of the system. 
 
         The value is computed with the following formula Eq. 5 of
@@ -371,7 +371,7 @@ class Cell(Sensor):
             return self._kappa
         
         if self.probe_tuple is None:
-            raise RydiquleError("Cell.probe_tuple not set. Either set manually or add at least one coupling before calculation.")
+            raise RydiquleError("Cell.probe_tuple not set. Add at least one coupling before calculation.")
         
         ground_manifold = self.states_with_spec(self.probe_tuple[0])
         excited_manifold = self.states_with_spec(self.probe_tuple[1])
@@ -396,6 +396,7 @@ class Cell(Sensor):
         dipole_moment = self.atom.get_dipole_matrix_element(probe_g_nlj, probe_e_nlj, q=q)*a0*e
 
         kappa = calc_kappa(omega_rad, dipole_moment, self.density)
+        self._kappa = kappa
     
         return kappa
 
@@ -435,7 +436,7 @@ class Cell(Sensor):
     
 
     @property
-    def eta(self):
+    def eta(self) -> float:
         """Get the eta value for the system.
 
         The value is computed with the following formula Eq. 7 of
@@ -461,7 +462,7 @@ class Cell(Sensor):
         if hasattr(self, "_eta"):
             return self._eta
         if self.probe_tuple is None:
-            raise RydiquleError("Cell.probe_tuple not set. Either set manually or add at least one coupling before calculation.")
+            raise RydiquleError("Cell.probe_tuple not set. Add at least one coupling before calculation.")
         
         ground_manifold = self.states_with_spec(self.probe_tuple[0])
         excited_manifold = self.states_with_spec(self.probe_tuple[1])
@@ -485,12 +486,13 @@ class Cell(Sensor):
         omega_rad = self.atom.get_transition_frequency(probe_g_nlj, probe_e_nlj)*2.0*np.pi
         dipole_moment = self.atom.get_dipole_matrix_element(probe_g_nlj, probe_e_nlj, q=q)*a0*e
         eta = calc_eta(omega_rad, dipole_moment, self.beam_area)
+        self._eta = eta
 
         return eta
     
 
     @eta.setter
-    def eta(self, value):
+    def eta(self, value: float):
         """Setter for the eta attribute.
 
         Updates the self._eta class attribute.
@@ -521,7 +523,7 @@ class Cell(Sensor):
 
 
     @property
-    def probe_freq(self):
+    def probe_freq(self) -> float:
         """Get the probe transition frequency, in rad/s.
 
         Note that for :class:`~.Cell`, probing transition frequency is calculated using only
@@ -537,6 +539,8 @@ class Cell(Sensor):
 
         if hasattr(self, '_probe_freq'):
             return self._probe_freq
+        if self.probe_tuple is None:
+            raise RydiquleError("Cell.probe_tuple not set. Add at least one coupling before calculation.")
         
         probe_lower_manifold = self.states_with_spec(self.probe_tuple[0])
         probe_upper_manifold = self.states_with_spec(self.probe_tuple[1])
@@ -546,11 +550,14 @@ class Cell(Sensor):
 
         energy_lower = self.atom.get_state_energy(A_QState(n1, l1, j1), s=0.5)*2*np.pi
         energy_upper = self.atom.get_state_energy(A_QState(n2, l2, j2), s=0.5)*2*np.pi
+
+        probe_freq = abs(energy_upper - energy_lower)
+        self._probe_freq = probe_freq
         
-        return np.abs(energy_upper - energy_lower)
+        return probe_freq
     
     @probe_freq.setter
-    def probe_freq(self, value):
+    def probe_freq(self, value: float):
         """Setter for the probe_freq attribute.
 
         Updates the self._probe_freq class attribute.

--- a/src/rydiqule/cell.py
+++ b/src/rydiqule/cell.py
@@ -5,7 +5,8 @@ Subclass of `Sensor` with functionality for representing real atoms.
 import scipy
 import numpy as np
 import warnings
-import itertools 
+import itertools
+import math
 
 import scipy.constants
 from scipy.constants import Boltzmann, e
@@ -185,20 +186,20 @@ class Cell(Sensor):
         self.temp = temp  # K
         self.beam_area = beam_area
         self.density = self.atom.arc_atom.getNumberDensity(self.temp)
-        self.atom_mass = self.atom.arc_atom.mass
+        self.atom_mass: float = self.atom.arc_atom.mass
         if beam_diam is None:
-            self.beam_diameter = 2.0*np.sqrt(beam_area/np.pi)
+            self.beam_diameter = 2.0*math.sqrt(beam_area/np.pi)
         else:
             self.beam_diameter = beam_diam
 
         if gamma_transit is None:
-            gamma_transit = 1E-6*np.sqrt(8*Boltzmann*self.temp/(self.atom_mass*np.pi)
-                                         )/(self.beam_diameter/2*np.sqrt(2*np.log(2)))
+            gamma_transit = 1E-6*math.sqrt(8*Boltzmann*self.temp/(self.atom_mass*np.pi)
+                                         )/(self.beam_diameter/2*math.sqrt(2*math.log(2)))
         self.gamma_transit = gamma_transit
 
         # most probable speed for a 3D Maxwell-Boltzmann distribution
         # used when defining doppler averaging
-        self.vP = np.sqrt(2*Boltzmann*self.temp/self.atom_mass)
+        self.vP = math.sqrt(2*Boltzmann*self.temp/self.atom_mass)
    
         self._add_state_energies()
         self._add_state_lifetimes()
@@ -905,7 +906,7 @@ class Cell(Sensor):
             lam = abs(self.atom.get_transition_wavelength(state1, state2)) # in m
             kvec = 2*np.pi/lam*np.asarray(kunit)*1e-6 # scaled to Mrad/m
         else:
-            raise RydiquleError(f'Coupling {states} has un-normalized |kunit|={np.sqrt(k_norm_sq):.2f}!=1')
+            raise RydiquleError(f'Coupling {states} has un-normalized |kunit|={math.sqrt(k_norm_sq):.2f}!=1')
 
         super().add_single_coupling(states=states,
                                     rabi_frequency=passed_rabi,

--- a/src/rydiqule/cell.py
+++ b/src/rydiqule/cell.py
@@ -204,6 +204,7 @@ class Cell(Sensor):
         self._add_state_lifetimes()
         self._add_decoherence_rates()
         self._add_gamma_mismatches(gamma_mismatch)
+        self.add_transit_broadening(gamma_transit)
 
     
     def set_experiment_values(self,

--- a/src/rydiqule/sensor_solution.py
+++ b/src/rydiqule/sensor_solution.py
@@ -543,7 +543,7 @@ class Solution():
 
         """
 
-        probe_wavelength = np.abs(c/(self.probe_freq/(2*np.pi))) #meters
+        probe_wavelength = abs(c/(self.probe_freq/(2*np.pi))) #meters
         probe_wavevector = 2*np.pi/probe_wavelength #1/meters
         OD = self.get_susceptibility().imag*self.cell_length*probe_wavevector
         if np.any(OD > 1.0):

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -82,7 +82,6 @@ def test_dipole_scaling(Rb85_sensor_kwargs):
 
 
 @pytest.mark.structure
-@pytest.mark.dev
 def test_decoherences():
     """Confirms that the decoherence matrix is building correctly.
     """
@@ -124,6 +123,61 @@ def test_decoherences():
     np.testing.assert_allclose(cell.decoherence_matrix(), gamma_expected,
                                atol=2*np.pi*1e-4, rtol=0,
                                err_msg='gamma matrix for 2-photon;1 RF not equal')
+
+
+@pytest.mark.structure
+def test_gamma_mismatching_NLJ():
+    """Tests that mismatch handling mechanisms in Cell work as intended with NLJ systems
+    """
+
+    g = rq.A_QState(5, 0, 0.5)
+    e = rq.A_QState(5, 1, 1.5)
+    r = rq.A_QState(50, 2, 2.5)
+
+    c = rq.Cell('Rb85', [g,e,r], gamma_mismatch='ground', gamma_transit=0)
+    lifetimes = np.array([c.couplings.nodes[n]['gamma_lifetime'] for n in c.couplings.nodes])
+    dephasings = c.decoherence_matrix()
+    # sum of all dephasings to lower states for each state (ie each row) should equal lifetime
+    mismatches = np.sum(dephasings, axis=1)
+    np.testing.assert_allclose(lifetimes, mismatches,
+                            err_msg='NLJ: ground-mismatch disagreement')
+  
+    c = rq.Cell('Rb85', [g,e,r], gamma_mismatch='all', gamma_transit=0)
+    lifetimes = np.array([c.couplings.nodes[n]['gamma_lifetime'] for n in c.couplings.nodes])
+    dephasings = c.decoherence_matrix()
+    # full dephasing rate should be to next lower state only (ie first sub-diagonal)
+    mismatches = np.diag(dephasings, k=-1)
+    np.testing.assert_allclose(lifetimes[1:], mismatches,
+                            err_msg='NLJ: all-mismatch disagreement')
+    
+
+@pytest.mark.structure
+def test_gamma_mismatch_groups():
+    """Tests that mismatch handling mechanisms in Cell work as intended with HFS systems
+    """
+
+    g = rq.A_QState(5, 0, 0.5, f=1, m_f='all')
+    e = rq.A_QState(5, 1, 1.5, f=1, m_f='all')
+
+    c = rq.Cell('Rb87', [g,e], gamma_mismatch='none', gamma_transit=0)
+    dipole_allowed_dephasings_mask = c.decoherence_matrix() != 0.0
+
+    c = rq.Cell('Rb87', [g,e], gamma_mismatch='ground', gamma_transit=0)
+    lifetimes = np.array([c.couplings.nodes[n]['gamma_lifetime'] for n in c.couplings.nodes])
+    dephasings = c.decoherence_matrix()
+    mismatches = np.sum(dephasings, axis=1)
+    np.testing.assert_allclose(lifetimes, mismatches,
+                               atol=1e-7, # need atol since comparing against 0
+                               err_msg='HFS: ground-mismatch disagreement')
+    
+    c = rq.Cell('Rb87', [g,e], gamma_mismatch='all', gamma_transit=0)
+    lifetimes = np.array([c.couplings.nodes[n]['gamma_lifetime'] for n in c.couplings.nodes])
+    dephasings = c.decoherence_matrix()
+    masked_dephasings = np.where(dipole_allowed_dephasings_mask, dephasings, 0) # ensure we don't sum accidental 'new' dephasings
+    mismatches = np.sum(masked_dephasings, axis=1)
+    np.testing.assert_allclose(lifetimes, mismatches,
+                               atol=1e-7, # need atol since comparing against 0
+                               err_msg='HFS: all-mismatch disagreement')
 
 
 @pytest.mark.structure

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -82,7 +82,8 @@ def test_dipole_scaling(Rb85_sensor_kwargs):
 
 
 @pytest.mark.structure
-def test_decoherences(Rb85_sensor_kwargs):
+@pytest.mark.dev
+def test_decoherences():
     """Confirms that the decoherence matrix is building correctly.
     """
     gState = A_QState(5, 0, 0.5)
@@ -100,7 +101,7 @@ def test_decoherences(Rb85_sensor_kwargs):
     riDecay = atom.getTransitionRate(*rState[:3], *iState[:3])*1e-6
     rrcDecay = atom.getTransitionRate(*rState[:3], *rcState[:3])*1e-6
     rcgDecay = atom.getTransitionRate(*rcState[:3], *gState[:3])*1e-6
-    transit = 2*np.pi*65.5286e-3*0
+    transit = 2*np.pi*65.5286e-3
 
     # calculates all dipole allowed dephasings
     # any dephasing not accounted for from the natural lifetime
@@ -117,8 +118,8 @@ def test_decoherences(Rb85_sensor_kwargs):
     gamma_expected[:, 0] += transit
 
     cell = rq.Cell('Rb85', [gState, iState, rState, rcState], 
-                   **Rb85_sensor_kwargs)
-    cell.add_transit_broadening(transit)
+                   gamma_transit=transit,
+                   )
 
     np.testing.assert_allclose(cell.decoherence_matrix(), gamma_expected,
                                atol=2*np.pi*1e-4, rtol=0,


### PR DESCRIPTION
Fixing a number of outstanding issues with `Cell`, revealed by trying to fix issues revealed by #37.

Improves unit testing around the revealed issues, ensure `Cell` actually adds transit broadening, and improves minor aspects for typing and caching of `eta`, `kappa`, and `probe_freq` properties.

Fixes #37 

