### PR TITLE
Tidy up tests

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,6 +28,7 @@ Bug Fixes
 - Fix errors in `gamma_mismatch` calculations when coupling groups are used.
   Also fix issue that prevented `gamma_mismatch='all'` from working if only 1 dephasing is present that needs modification.
 - Update RF heterodyne example notebook to use new `Cell` syntax.
+- Properly mark slow/high-memory analytic doppler test.
 
 Deprecations
 ++++++++++++

--- a/docs/source/dev/tests.rst
+++ b/docs/source/dev/tests.rst
@@ -73,6 +73,8 @@ The markers we use are
     - Marks a test of the definition of the atomic system.
   * - exception
     - Marks a test of error handling.
+  * - backend
+    - Marks a test that uses an optional backend
   * - dev
     - Used to temporarily mark a single test that is being developed so it can run independently.
 

--- a/tests/test_analytic_doppler.py
+++ b/tests/test_analytic_doppler.py
@@ -96,6 +96,8 @@ def test_analytic_1D_doppler():
                                err_msg='Sampled and analytic 1D doppler do not match')
     
 
+@pytest.mark.slow
+@pytest.mark.high_memory
 @pytest.mark.steady_state
 @pytest.mark.doppler
 def test_analytic_2D_doppler():

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -6,7 +6,6 @@ from rydiqule.atom_utils import A_QState
 
 
 @pytest.mark.time
-@pytest.mark.slow
 @pytest.mark.doppler
 def test_rabi_flop_doppler():
     """Tests that time solver functions with Doppler broadening


### PR DESCRIPTION
Found that the 2D analytic doppler unit test is both slow and high-memory, but not marked as such.

Fixed that and cleaned up a few loose ends. Tests should run much faster.