### PR TITLE
Pin scipy<1.17 to work around ARC incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires-python = ">= 3.8"
 dependencies = [
     "arc-alkali-rydberg-calculator>=3.5.0",
     "numpy",
-    "scipy>=0.19.1",
+    "scipy>=0.19.1, <1.17",
     "leveldiagram>=0.3.1",
     "networkx",
     "psutil",


### PR DESCRIPTION
Fixes #52 

When ARC gets updated, will remove this pin and instead pin to the newest version of ARC.